### PR TITLE
Fix: Make footer display in a single column on small screens

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -998,16 +998,22 @@ details[open] .table-of-contents-summary,
     padding: 1rem;
   }
 
-  .footer-columns {
-    grid-template-columns: 1fr;
-    gap: 2rem;
+  .footer-content {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .footer-column {
+    width: 100%;
+    max-width: 500px;
+    margin-bottom: var(--s2, 1.5rem);
   }
 
   .quote {
-    padding-right: 0;
-    padding-bottom: 2rem;
     border-right: none;
     border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    padding-bottom: var(--s2, 1.5rem);
+    padding-right: 0;
   }
 
   .social-section {


### PR DESCRIPTION
I've updated `src/styles/global.css` to change the footer layout to a single column for screen widths up to 768px.

- I modified `.footer-content` within the `@media (max-width: 768px)` query to use `flex-direction: column`.
- I ensured `.footer-column` elements take full width in the single-column layout.
- I adjusted borders for the `.quote` column, removing the right border and adding a bottom border for the stacked layout.
- I removed unused `.footer-columns` styles.

The footer now correctly stacks its columns on smaller screens, improving readability and your experience on mobile devices.

## Summary by Sourcery

Make footer columns stack vertically on screens up to 768px to improve mobile readability by updating CSS layout and styling.

Enhancements:
- Convert footer layout to a flex column under the 768px breakpoint and center-align its content
- Expand footer columns to full width with a max-width constraint for better small-screen presentation
- Adjust the quote section’s borders and paddings for the stacked layout

Chores:
- Remove unused .footer-columns CSS rules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the footer layout for improved mobile presentation.
  * Centered footer content vertically with consistent spacing.
  * Constrained footer column widths and refined quote spacing while preserving the divider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->